### PR TITLE
There are 3 fixes and 1 addition for Japanese support.

### DIFF
--- a/data/upg-apply.desktop
+++ b/data/upg-apply.desktop
@@ -1,8 +1,10 @@
 [Desktop Entry]
 Exec=lxqt-sudo /usr/bin/lubuntu-upgrader --cache-update --full-upgrade
 Name=Apply Full Upgrade
+Name[ja]=すべてのアップグレードの適用 (Apply Full Upgrade)
 GenericName=Apply Full Upgrade
 Comment=Search and Apply Full Upgrade
+Comment[ja]=すべてのアップグレードの検索と適用
 Icon=system-software-update
 Type=Application
 Version=0.1

--- a/lubuntu-upgrader
+++ b/lubuntu-upgrader
@@ -236,12 +236,12 @@ class DialogUpg(QWidget):
     def upgrade_error(self, transaction, error_code, error_details):
         '''if error during upgrade'''
         self.plainTextEdit.setVisible(True)
-        self.errors.append("Eror Code: " + str(error_code))
+        self.errors.append("Error Code: " + str(error_code))
         self.errors.append("Error Detail: " + error_details)
         self.plainTextEdit.setVisible(True)
         self.closeBtn.setEnabled(True)
-        print("ECode: " + str(error_code) + "\n")
-        print("EDetail: " + error_details + "\n")
+        print(_("ECode: ") + str(error_code) + "\n")
+        print(_("EDetail: ") + error_details + "\n")
 
     def upgrade_cancellable_changed(self, transaction, cancellable):
         '''when upgrade cancellable toogle'''
@@ -266,7 +266,7 @@ class DialogUpg(QWidget):
             self.trans1.run()
 
         except (NotAuthorizedError, TransactionFailed) as e:
-            print("Warning: install transaction not completed successfully:"
+            print(_("Warning: install transaction not completed successfully:")
                   + "{}".format(e))
 
     def update_finish(self, transaction, exit_state):
@@ -310,7 +310,7 @@ class DialogUpg(QWidget):
                 self.label.setText(self.detailText + "\n" + details)
                 # if is downloading put the "Downloaded x of y" text
             # print("PTY:" + str(self.slave))
-            print("Status Details:" + details)
+            print(_("Status Details:") + details)
 
     def upgrade(self):
         '''runs upgrade'''
@@ -342,7 +342,7 @@ class DialogUpg(QWidget):
             self.trans2.run()
 
         except (NotAuthorizedError, TransactionFailed) as e:
-            print("Warning: install transaction not completed successfully:"
+            print(_("Warning: install transaction not completed successfully:")
                   + "{}".format(e))
 
     def call_reject(self):

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,143 +1,139 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-01-19 22:14+0900\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2021-01-19 23:30+0900\n"
+"Last-Translator: FuRuYa7\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 #: lubuntu-upgrader:129
 msgid "Updating cache..."
-msgstr ""
+msgstr "キャッシュを更新中..."
 
 #: lubuntu-upgrader:186 lubuntu-upgrader:189
 msgid "Fetching"
-msgstr ""
+msgstr "読み出し中"
 
 #: lubuntu-upgrader:187 lubuntu-upgrader:189 lubuntu-upgrader:200
 #: lubuntu-upgrader:203
+# "「の」に翻訳すると意味が反転するので注意"
 msgid "of"
-msgstr ""
+msgstr " / "
 
 #: lubuntu-upgrader:199 lubuntu-upgrader:202
 msgid "Downloaded"
-msgstr ""
+msgstr "ダウンロード済みです"
 
 #: lubuntu-upgrader:214 lubuntu-notifier.py:204
 msgid "Upgrade finished"
-msgstr ""
+msgstr "アップグレードが完了しました"
 
 #: lubuntu-upgrader:218 lubuntu-notifier.py:169 lubuntu-notifier.py:173
 #: lubuntu-notifier.py:208
 msgid "Reboot required"
-msgstr ""
+msgstr "再起動が必要です"
 
 #: lubuntu-upgrader:222
 msgid "With some Errors"
-msgstr ""
+msgstr "いくつかのエラーがあります"
 
 #: lubuntu-upgrader:223
 msgid "Error Resume:"
-msgstr ""
+msgstr "エラー再開:"
 
 #: lubuntu-upgrader:243
 msgid "ECode: "
-msgstr ""
+msgstr "エラーコード: "
 
 #: lubuntu-upgrader:244
 msgid "EDetail: "
-msgstr ""
+msgstr "エラーの詳細: "
 
 #: lubuntu-upgrader:269 lubuntu-upgrader:345
 msgid "Warning: install transaction not completed successfully:"
-msgstr ""
+msgstr "警告: インストール処理が正常に完了しませんでした:"
 
 #: lubuntu-upgrader:274
 msgid "Update Cache Finished"
-msgstr ""
+msgstr "キャッシュの更新が完了しました"
 
 #: lubuntu-upgrader:313
 msgid "Status Details:"
-msgstr ""
+msgstr "ステータスの詳細:"
 
 #: lubuntu-upgrader:369
 msgid ""
 "Please run this software with administrative rights.To do so, run this "
 "program with lxqt-sudo."
-msgstr ""
+msgstr "管理者権限で実行してください。lxqt-sudo を使用して実行します。"
 
 #: lubuntu-upgrader:391
 msgid "Update Cache Before Upgrade"
-msgstr ""
+msgstr "アップグレード前にキャッシュを更新します"
 
 #: lubuntu-upgrader:396
 msgid "Full upgrade same as dist-upgrade"
-msgstr ""
+msgstr "dist-upgrade と同じ完全アップグレード"
 
 #: lubuntu-notifier.py:54
 #, python-format
 msgid "Error: Opening the cache (%s)"
-msgstr ""
+msgstr "エラー: キャッシュ (%s) を開いています"
 
 #: lubuntu-notifier.py:71 lubuntu-notifier.py:77
 msgid "Affected Packages"
-msgstr ""
+msgstr "影響を受けるパッケージ"
 
 #: lubuntu-notifier.py:72
 msgid "Security"
-msgstr ""
+msgstr "セキュリティ"
 
 #: lubuntu-notifier.py:117
 msgid "There are upgrades available. Do you want to do a system upgrade?"
-msgstr ""
+msgstr "利用可能なアップグレードがあります。システムのアップグレードを行いますか？"
 
 #: lubuntu-notifier.py:120
 msgid "This will mean packages could be upgraded, installed or removed."
-msgstr ""
+msgstr "パッケージがアップグレード、インストール、または削除されます。"
 
 #: lubuntu-notifier.py:125
 msgid " is a security upgrade."
-msgstr ""
+msgstr " 個がセキュリティのアップグレードです。"
 
 #: lubuntu-notifier.py:127
 msgid " are security upgrades."
-msgstr ""
+msgstr " 個がセキュリティのアップグレードです。"
 
 #: lubuntu-notifier.py:130
 msgid "Remove"
-msgstr ""
+msgstr "削除"
 
 #: lubuntu-notifier.py:137
 msgid "Install"
-msgstr ""
+msgstr "インストール"
 
 #: lubuntu-notifier.py:152
 msgid "Upgrade"
-msgstr ""
+msgstr "アップグレード"
 
 #: lubuntu-notifier.py:194
 msgid "Upgrading..."
-msgstr ""
+msgstr "アップグレード中..."
 
 #: lubuntu-notifier.py:247
 msgid "Define software/app to open for upgrade"
-msgstr ""
+msgstr "アップグレードで開くソフトウェア/アプリを定義します"
 
 #: lubuntu-notifier.py:252
 msgid "How many upgrades are available"
-msgstr ""
+msgstr "利用可能なアップグレードの数"
 
 #: lubuntu-notifier.py:257
 msgid "How many security upgrades are available"
-msgstr ""
+msgstr "利用可能なセキュリティアップグレードの数"


### PR DESCRIPTION
#### There are 3 fixes and 1 addition for Japanese support.

1. Japanese has been added to the "**data/upg-apply.desktop**" file.

2. The "**lubuntu-upgrader**" file has added the character string to be translated.

3. The "**po/lubuntu-update-notifier.pot**" file was modified to "**charset = UTF-8**" and recreated, including additions.

4. Added Japanese "**po/ja.po**" file.
